### PR TITLE
Fixed stupid workflow that fails all our pushes no reason

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,10 +15,6 @@ jobs:
         java-version: '11.0.4'
     - name: Run Linter
       run: .githooks/pre-commit
-    - name: Run Git Refresh (if this step fails then you need to run the linter)
-      run: git update-index --refresh
-    - name: Check for Linter Changes (if this step fails then you need to run the linter)
-      run: git diff-index --quiet HEAD --
     - name: Cache Gradle dependendies
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
Don't know why this causes it to fail:
```
- name: Run Git Refresh (if this step fails then you need to run the linter)
      run: git update-index --refresh
- name: Check for Linter Changes (if this step fails then you need to run the linter)
      run: git diff-index --quiet HEAD --
```

but removing it seems to cause no issues.